### PR TITLE
DEFECT: Allowing Book Cover API calls for empty author

### DIFF
--- a/src/main/java/com/example/aml/service/BookCoverService.java
+++ b/src/main/java/com/example/aml/service/BookCoverService.java
@@ -19,6 +19,9 @@ public class BookCoverService {
 
     public String getBookCoverURL(String bookTitle, String authorName) {
         RestTemplate restTemplate = new RestTemplate();
+        if (authorName.isEmpty()) {
+            authorName = " ";
+        }
         String apiUrl = bookCoverApiUrl + "?book_title=" + bookTitle + "&author_name=" + authorName;
         String url = null;
         try {


### PR DESCRIPTION
### Ticket
Closes #49 

### Information
**What?**
Allowing Book Cover API calls for empty author.

**Why?**
Some books won't have a known author.

**How?**
Checking if the author field is empty. If it is, we add a space.

### Code Checklist
- [ ] Did I manually test my changes, or contact @Adam1302 to test my changes on the remote branch?
- [ ] Did I document my changes such that a new dev or a learner might understand them?

